### PR TITLE
Update node engine version constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "engines": {
-    "node": "~0.10.22"
+    "node": ">=0.10.22"
   },
   "dependencies": {
     "debuglog": "^1.0.1",


### PR DESCRIPTION
`~0.10.22` is outdated for current node versions